### PR TITLE
Fix Dockerfile CMD foramt used together with ENTRYPOINT

### DIFF
--- a/vzstorage-pd/virtuozzo-provisioner.go
+++ b/vzstorage-pd/virtuozzo-provisioner.go
@@ -136,7 +136,7 @@ func (p *vzFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Persi
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				FlexVolume: &v1.FlexVolumeSource{
-					Driver:  "jaxxstorm/ploop",
+					Driver:  "virtuozzo/ploop",
 					Options: ploop_options,
 				},
 			},


### PR DESCRIPTION
Problem:
After run virtuozzo-storage, CMD params are not passed to vzstorage-pd
ENTRYPOINT. It's simple and always reproducable.
Looks like this is due to Dockerfile "feature"
(https://docs.docker.com/engine/reference/builder/#cmd)
----
Note: If CMD is used to provide default arguments for the ENTRYPOINT
instruction, both the CMD and ENTRYPOINT instructions should be specified
with the JSON array format.
----
After I have localy fixed to json format, vzstorage-pd start using these
params.

Signed-off-by: Anton Kurbatov <akurbatov@virtuozzo.com>