### PR TITLE
vzstorage-pd: don't use claim labels to pass ploop parameters

### DIFF
--- a/vzstorage-pd/README.md
+++ b/vzstorage-pd/README.md
@@ -47,26 +47,5 @@ kubectl create -f test-pod.yaml
 
 A storage class parameters pass as ploop options to the ploop-flexvol driver.
 
-Another way to pass ploop options is to use labels in claims. In this case all special symbols (e.g. +,/, etc) have to be replaced by dots.
-
-Labels in claims can be used to pass ploop options, but all special symbols has to be replaced by dots.
- kind: PersistentVolumeClaim
- apiVersion: v1
- metadata:
-   name: vz-test-claim
-   annotations:
-     volume.beta.kubernetes.io/storage-class: "virtuozzo-storage"
- spec:
-   accessModes:
-     - ReadWriteOnce
-     - ReadOnlyMany
-   resources:
-     requests:
-       storage: 1Gi
-   selector:
-     matchLabels:
-       vzsTier: "0"
-       vzsReplicas: "2.1.3"
-
 # Known limitations
 Vstorage must be mounted manually on all cluster nodes

--- a/vzstorage-pd/claim.yaml
+++ b/vzstorage-pd/claim.yaml
@@ -11,7 +11,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  selector:
-    matchLabels:
-      vzsTier: "0"
-      vzsReplicas: "2.1.3"


### PR DESCRIPTION
All parameters have to be set in a storage class.

Signed-off-by: Andrei Vagin <avagin@openvz.org>