### PR TITLE
virtuozzo-provisioner.go: copy VolumeOptions.Parameters into ploop_options

### DIFF
--- a/vzstorage-pd/virtuozzo-provisioner.go
+++ b/vzstorage-pd/virtuozzo-provisioner.go
@@ -89,7 +89,10 @@ func (p *vzFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Persi
 		labels = options.PVC.Spec.Selector.MatchLabels
 	}
 
-	ploop_options := options.Parameters
+	ploop_options := map[string]string{}
+	for k,v := range options.Parameters {
+		ploop_options[k] = v
+	}
 
 	ploop_options["volumeId"] = share
 	ploop_options["size"] = fmt.Sprintf("%d", bytes)


### PR DESCRIPTION
VZAP-201

Otherwise code updates storageClass.Parameters map with
vzsReplicas/vzsTier and otheres values. This solves issue when request
to create some new claim with new set of options leads to creation of
claim with previously stored set options, even if options were not set
in resource yaml file of PVC.

Signed-off-by: Anton Kurbatov <akurbatov@virtuozzo.com>