### PR TITLE
Add support for storage leader election

### DIFF
--- a/vzstorage-pd/virtuozzo-provisioner.go
+++ b/vzstorage-pd/virtuozzo-provisioner.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-incubator/external-storage/lib/leaderelection"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -47,6 +48,10 @@ const (
 	failedRetryThreshold      = 5
 	parentProvisionerAnn      = "vzFSParentProvisioner"
 	vzShareAnn                = "vzShare"
+	leasePeriod               = leaderelection.DefaultLeaseDuration
+	retryPeriod               = leaderelection.DefaultRetryPeriod
+	renewDeadline             = leaderelection.DefaultRenewDeadline
+	termLimit                 = leaderelection.DefaultTermLimit
 )
 
 type provisionOutput struct {


### PR DESCRIPTION
When running the provisioner as a systemd unit (ie outside the cluster) - it's possible to have multiple provisioners running, usually on every node.

The external-storage repo has support for very simple leaderelection. The package is located [here](https://github.com/kubernetes-incubator/external-storage/blob/master/lib/leaderelection/leaderelection.go). As per the comments there:

> // This is a modified version of kube's leaderelection package which uses a
// dummy endpoints object & its annotation as a lock. Here a pvc is used and
// the lock is to help ensure only one provisioner (the leader) is trying to
// provision a volume for the pvc at a time. So the election lasts only until
// the task is completed. Adds also a 'TermLimit.'

So with that in mind, adding these constants will allow a provisioner to take control of volume creation if running multiple provisioners. This also will come in handy if you're running a deployment with more than 1 replica.
