### PR TITLE
vzstorage-pd: revoke lease before deleting an image file

### DIFF
--- a/vzstorage-pd/Makefile
+++ b/vzstorage-pd/Makefile
@@ -5,7 +5,7 @@ GITID	?= $(shell git describe --always HEAD || true)
 TARNAME	:= $(NAME)-$(GITID)
 
 all:
-	go build .
+	go build -i .
 .PHONY: all
 
 tar: $(TARNAME).tar.bz2


### PR DESCRIPTION
If a file is used by someone, it can't be deleted without
revoking its lease.

https://github.com/virtuozzo/external-storage/issues/32
Signed-off-by: Andrei Vagin <avagin@virtuozzo.com>