### PR TITLE
Read secrets from kube system

### DIFF
--- a/vzstorage-pd/Dockerfile
+++ b/vzstorage-pd/Dockerfile
@@ -4,6 +4,6 @@ ENTRYPOINT ["vzstorage-pd"]
 ADD virtuozzo.repo /etc/yum.repos.d/
 ADD vzlinux.repo /etc/yum.repos.d/
 ADD openvz-factory.repo /etc/yum.repos.d/
-RUN printf "upgrade \n install vstorage-ctl vstorage-client ploop gdisk \n run" | yum shell -y
+RUN printf "upgrade \n install vstorage-ctl vstorage-client ploop gdisk \n clean all \n run" | yum shell -y
 
 ADD vzstorage-pd /usr/bin/

--- a/vzstorage-pd/README.md
+++ b/vzstorage-pd/README.md
@@ -43,6 +43,44 @@ kubectl create -f claim.yaml
 kubectl create -f test-pod.yaml
 ```
 
+# Storage Class options
+
+By default, the storage class accepts the following parameters:
+
+```
+parameters:
+  volumePath: "k8s-volumes"
+  deltasPath: "k8s-deltas"
+  secretName: "virtuozzo-secret"
+```
+
+This will search for a Secret object called **"virtuozzo-secret"** in each namespace with a PVC using this storage class.
+This behaviour can be turned off using **secretFromSystem**:
+
+```
+parameters:
+  volumePath: "k8s-volumes"
+  deltasPath: "k8s-deltas"
+  secretName: "virtuozzo-secret"
+  secretFromSystem: "true"
+```
+
+If this option is set to _"true"_, the storage provisioner will search for this Secret object in the kube-system namespace.
+When this option is enabled, credentials should be passed to ploop-flexvol using environment variables
+
+```bash
+# cat /etc/systemd/system/kubelet.service.d/15-ploop.conf
+[Service]
+EnvironmentFile=/etc/sysconfig/ploop-flexvol
+# cat /etc/sysconfig/ploop-flexvol
+clusterName="base64encodedClusterName"
+clusterPassword="base64encodedPassword"
+workingDir="/vstorage"
+```
+
+
+
+
 # Ploop options
 
 A storage class parameters pass as ploop options to the ploop-flexvol driver.

--- a/vzstorage-pd/virtuozzo-provisioner.go
+++ b/vzstorage-pd/virtuozzo-provisioner.go
@@ -303,12 +303,12 @@ func (p *vzFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Persi
 	storageClassOptions["volumeID"] = share
 	storageClassOptions["size"] = fmt.Sprintf("%d", bytes)
 	secretName := storageClassOptions["secretName"]
-	secretFromSystem := storageClassOptions["secretFromSystem"]
+	optionsFromSystem := storageClassOptions["optionsFromSystem"]
 
 	secretNamespace := options.PVC.Namespace
 	secretRef := &v1.LocalObjectReference{Name: secretName}
 
-	if secretFromSystem == "true" {
+	if optionsFromSystem == "true" {
 		secretNamespace = "kube-system"
 		secretRef = nil
 	} else {
@@ -400,10 +400,10 @@ func (p *vzFSProvisioner) Delete(volume *v1.PersistentVolume) error {
 	var secretName string
 	options := volume.Spec.PersistentVolumeSource.FlexVolume.Options
 
-	secretFromSystem := options["secretFromSystem"]
+	optionsFromSystem := options["optionsFromSystem"]
 	secretNamespace := volume.Spec.ClaimRef.Namespace
 
-	if secretFromSystem == "true" {
+	if optionsFromSystem == "true" {
 		secretNamespace = "kube-system"
 		secretName = options["secretName"]
 	} else {

--- a/vzstorage-pd/virtuozzo-provisioner.go
+++ b/vzstorage-pd/virtuozzo-provisioner.go
@@ -311,7 +311,7 @@ func (p *vzFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Persi
 	if secretFromSystem == "true" {
 		secretNamespace = "kube-system"
 		secretRef = nil
-	}else{
+	} else {
 		delete(storageClassOptions, "secretName")
 	}
 
@@ -406,7 +406,7 @@ func (p *vzFSProvisioner) Delete(volume *v1.PersistentVolume) error {
 	if secretFromSystem == "true" {
 		secretNamespace = "kube-system"
 		secretName = options["secretName"]
-	}else{
+	} else {
 		secretName = volume.Spec.PersistentVolumeSource.FlexVolume.SecretRef.Name
 	}
 


### PR DESCRIPTION
In our environment, we don't want to deploy the Secret object with the cluster credentials to each and every namespace using this storage provisioner.
This patch adds a new configuration option **secretFromSystem** (boolean). If this flag is enabled, it will always search for the Secret object in the _kube-system_ namespace, so our end users don't need to need to deploy a Secret object in their namespaces.

Another option would be to specify a namespace instead of a boolean flag.
